### PR TITLE
b-0.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,9 @@ dependencies {
     //runtime "ch.qos.logback:logback-classic:1.2.3"
 
     testCompile "org.scalatest:scalatest_$scalaMajor:$scalatestVersion"
+    testCompile "org.scalatestplus:scalatestplus-junit_$scalaMajor:$scalatestplusVersion"
     testCompile "com.typesafe.akka:akka-http-testkit_$scalaMajor:$akkaHttpVersion"
+    testCompile "com.typesafe.akka:akka-stream-testkit_$scalaMajor:$akkaStreamVersion"
     testCompile "com.stephenn:scalatest-circe_$scalaMajor:$scalatestCirceVersion"
     testCompile "com.github.stefanbirkner:fake-sftp-server-lambda:$fakeSftpServerVersion"
     testCompile "junit:junit:$junitVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -61,4 +61,4 @@ docker {
 }
 
 dockerPrepare.dependsOn copyDockerfile
-docker.dependsOn build as Task
+docker.dependsOn assembleDist as Task

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     testCompile "junit:junit:$junitVersion"
 }
 
-mainClassName = "com.github.ilittleangel.notifier.NotifierServer"
+mainClassName = "${group}.App"
 
 buildscript {
     repositories {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,128 @@
+# Troubleshooting Errors
+
+* [Malformed requests](#malformed-requests)
+* [Ftp errors](#ftp-errors)
+* [Slack errors](#slack-errors)
+* [Multi destination errors](#multi-destination-errors)
+
+
+
+## Malformed requests
+
+* If the request is sent with other destination the response will be a `400 Bad Request` and a message like this:
+```
+The request content was malformed:
+Expected (Ftp, Slack or Email) for 'destination' attribute
+```
+
+* Provide a `message` field is mandatory as well, if not will get a `400 Bad Request` response with a message like this:
+```
+The request content was malformed:
+Object is missing required member 'message'
+```
+
+* If there is no `properties` the response will be another `400 Bad Request`, but in this case will be more feedback:
+```json
+{
+    "status": 400,
+    "statusText": "Bad Request",
+    "reason": "Ftp alert with no properties",
+    "possibleSolution": "Include properties with 'host' and 'path'"
+}
+```
+
+
+
+## Ftp errors
+
+* When something wrong happens with a Ftp alert the body response will be as following:
+```json
+{
+    "alert": {
+        "destination": "ftp",
+        "message": "......",
+        "properties": {
+            ...
+        }
+    },
+    "isPerformed": false,
+    "status": "Ftp alert failed with IOResult[error=Connection refused (Connection refused), count=0]",
+    "description": "alert received but not performed!"
+}
+```
+
+* Only the `status` field will be change depending of what is the mistake in the incomming webhook url.
+* In such cases the `status` field give more information about the error. Some of these errors could be:
+
+| error                                                                                                  | description                                   | http status     |
+|:-------------------------------------------------------------------------------------------------------|:----------------------------------------------|-----------------|
+|`"status": "Ftp alert failed with IOResult[error=Connection refused (Connection refused), count=0]"`    | bad port                                      | 400 bad request |
+|`"status": "Ftp alert failed with IOResult[error=Exhausted available authentication methods, count=0]"` | authentication fail (bad username OR password)| 400 bad request |
+|`"status": "Ftp alert failed with an Exception [error=sftp-servexr: Name does not resolve]"`            | unknown server address                        | 400 bad request |
+|`"status": "Ftp alert failed with an Exception [error=sfatp (of class java.lang.String)]"`              | unknown protocol                              | 400 bad request |
+
+
+
+## Slack errors
+
+* When something wrong happens with a Slack alert the body response will be as following:
+```json
+{
+    "alert": {
+        "destination": "slack",
+        "message": "......",
+        "properties": {
+            ...
+        }
+    },
+    "isPerformed": false,
+    "status": "Slack webhook request failed [error=`uri` must have scheme \"http\", \"https\", \"ws\", \"wss\" or no scheme]",
+    "description": "alert received but not performed!"
+}
+```
+
+* Only the `status` field will be change depending of what is the mistake in the incomming webhook url.
+* In such cases the `status` field give more information about the error:
+
+|   | error                                                                                                                     | http status     |
+|---|:--------------------------------------------------------------------------------------------------------------------------|-----------------|
+| 1 | `"status": "Slack webhook request failed [error=uri must have scheme \"http\", \"https\", \"ws\", \"wss\" or no scheme]"` | 400 bad request |
+| 2 | `"status": "Slack webhook request failed [status=302 Found] [entity=]"`                                                   | 400 bad request |
+| 3 | `"status": "no_team"`                                                                                                     | 400 bad request |
+| 4 | `"status": "no_service"`                                                                                                  | 400 bad request |
+| 5 | `"status": "invalid_token"`                                                                                               | 400 bad request |
+
+The error depends on where the mistake is in the URL:
+```text
+https://hooks.slaack.com/services/TGYMK17R2/BW144ANYL/ssSOopvymUUAJnMflgu8LFdT
+ ^                          ^         ^         ^                 ^
+ 1                          2         3         4                 5
+```
+
+
+## Multi destination errors
+
+* If one of destinations failed, the HTTP response was a `400 Bad Request`
+* The Json body response will be as following:
+```json
+{
+    "alert": {
+        "destination": [
+            "slack",
+            "ftp"
+        ],
+        "message": "......",
+        "properties": {
+            ...
+        },
+        "ts": "2020-03-25T17:44:44.112Z"
+    },
+    "isPerformed": false,
+    "status": "Slack webhook request success [status=200 OK] [ok]; Ftp alert failed with IOResult[error=Connection refused (Connection refused), count=0]",
+    "description": "alert received but not performed!"
+}
+```
+* The `isPerformed` field will be `false`
+* The `description` field will be `alert received but not performed!`
+* The `status` field will be the concatenation of the `error` message received from each destination in the same order.
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Artifact version
-version = 0.2.0-SNAPSHOT
+version = 0.3.0-SNAPSHOT
 
 # Dependency versions
 scalaMajor= 2.12

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,16 @@
 version = 0.3.0-SNAPSHOT
 
 # Dependency versions
-scalaMajor= 2.12
-scalaMinor = 7
-akkaHttpVersion = 10.1.5
-typesafeConfigVersion = 1.3.3
+scalaMajor= 2.13
+scalaMinor = 1
+akkaHttpVersion = 10.1.12
+akkaStreamVersion = 2.6.4
+typesafeConfigVersion = 1.4.0
 scalatestVersion = 3.0.5
-scalatestCirceVersion = 0.0.1
+scalatestplusVersion = 1.0.0-M2
+scalatestCirceVersion = 0.0.4
 junitVersion = 4.12
-alpakkaVersion = 1.1.2
-scoptVersion = 3.7.0
+alpakkaVersion = 2.0.0
+scoptVersion = 3.7.1
 fakeSftpServerVersion = 1.0.0
 palantirDockerVersion = 0.20.1

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -4,4 +4,15 @@ akka {
   loglevel = "INFO"
   http.server.remote-address-header = on
 
+  http {
+    server {
+      idle-timeout = 60 seconds
+      bind-timeout = 10 seconds
+    }
+    client {
+      idle-timeout = 60 seconds
+      connecting-timeout = 30 seconds
+    }
+  }
+
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,7 +1,7 @@
 akka {
 
   # options: OFF, ERROR, WARNING, INFO, DEBUG
-  loglevel = "DEBUG"
+  loglevel = "INFO"
   http.server.remote-address-header = on
 
 }

--- a/src/main/scala/com/github/ilittleangel/notifier/package.scala
+++ b/src/main/scala/com/github/ilittleangel/notifier/package.scala
@@ -11,7 +11,7 @@ import scala.util.Try
 
 package object notifier {
 
-  final case class Alert(destination: Destination, message: String, properties: Option[Map[String, String]], ts: Option[Instant])
+  final case class Alert(destination: List[Destination], message: String, properties: Option[Map[String, String]], ts: Option[Instant])
   final case class ActionPerformed(alert: Alert, isPerformed: Boolean, status: String, description: String, clientIp: Option[String])
   final case class Alerts(alerts: List[ActionPerformed])
   final case class ErrorResponse(status: Int, statusText: String, reason: String, possibleSolution: Option[String] = None, clientIp: Option[String])
@@ -34,5 +34,14 @@ package object notifier {
   }
 
   def applyOrElse[A, B](optValue: Option[A])(f: A => B, default: B): B = optValue.map(f(_)).getOrElse(default)
+
+  /**
+   * Global constants
+   */
+  val DeserializationError = "Expected (Ftp, Slack or Email) for 'destination' attribute"
+  val AlertPerformed = "alert received and performed!"
+  val AlertNotPerformed = "alert received but not performed!"
+
+
 }
 

--- a/src/main/scala/com/github/ilittleangel/notifier/package.scala
+++ b/src/main/scala/com/github/ilittleangel/notifier/package.scala
@@ -15,6 +15,7 @@ package object notifier {
   final case class ActionPerformed(alert: Alert, isPerformed: Boolean, status: String, description: String, clientIp: Option[String])
   final case class Alerts(alerts: List[ActionPerformed])
   final case class ErrorResponse(status: Int, statusText: String, reason: String, possibleSolution: Option[String] = None, clientIp: Option[String])
+  final case class SuccessResponse(status: Int, statusText: String, reason: String, clientIp: Option[String])
 
   implicit class AlertOps(alert: Alert) {
     def ensureTimestamp(default: Instant): Alert = alert match {

--- a/src/main/scala/com/github/ilittleangel/notifier/server/JsonSupport.scala
+++ b/src/main/scala/com/github/ilittleangel/notifier/server/JsonSupport.scala
@@ -44,6 +44,7 @@ trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val alertsJsonBody: RootJsonFormat[Alerts] = jsonFormat1(Alerts)
   implicit val actionPerformedJsonFormat: RootJsonFormat[ActionPerformed] = jsonFormat5(ActionPerformed)
   implicit val errorResponseJsonFormat: RootJsonFormat[ErrorResponse] = jsonFormat5(ErrorResponse)
+  implicit val successResponseJsonFormat: RootJsonFormat[SuccessResponse] = jsonFormat4(SuccessResponse)
 
   implicit private class StrOps(str: String) {
     def toDestination: Destination = str.toLowerCase match {

--- a/src/main/scala/com/github/ilittleangel/notifier/server/NotifierRoutes.scala
+++ b/src/main/scala/com/github/ilittleangel/notifier/server/NotifierRoutes.scala
@@ -7,13 +7,11 @@ import akka.actor.ActorSystem
 import akka.event.{Logging, LoggingAdapter}
 import akka.http.scaladsl.model.StatusCodes.{BadRequest, OK}
 import akka.http.scaladsl.server.{Directives, Route}
-import akka.util.Timeout
 import com.github.ilittleangel.notifier.destinations.{Destination, Email, Ftp, Slack}
 import com.github.ilittleangel.notifier.utils.Eithers.FuturesEitherOps
 import com.github.ilittleangel.notifier.{ActionPerformed, Alert, ErrorResponse, _}
 
 import scala.concurrent.Future
-import scala.concurrent.duration._
 
 
 trait NotifierRoutes extends JsonSupport with Directives {
@@ -22,8 +20,6 @@ trait NotifierRoutes extends JsonSupport with Directives {
   implicit def system: ActorSystem
 
   lazy val log: LoggingAdapter = Logging(system, classOf[NotifierRoutes])
-
-  implicit lazy val timeout: Timeout = Timeout(10.seconds)
 
   def defaultTs: Instant = Instant.now()
 

--- a/src/main/scala/com/github/ilittleangel/notifier/utils/Eithers.scala
+++ b/src/main/scala/com/github/ilittleangel/notifier/utils/Eithers.scala
@@ -1,0 +1,53 @@
+package com.github.ilittleangel.notifier.utils
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object Eithers {
+
+  val separator = "; "
+  val concatStrings: (String, String) => String = (s1, s2) => s1 + separator + s2
+
+  implicit private class EitherOps(self: Either[String, String]) {
+    def applyAndForceLeft(s: String, f: (String, String) => String): Left[String, Nothing] = {
+      self match {
+        case Right(status) => Left(f(status, s))
+        case Left(error) => Left(f(error, s))
+      }
+    }
+
+    def applyAndForceRight(s: String, f: (String, String) => String): Right[Nothing, String] = {
+      self match {
+        case Right(status) => Right(f(status, s))
+        case Left(error) => Right(f(error, s))
+      }
+    }
+  }
+
+  val concatLeft: (Either[String, String], Either[String, String]) => Left[String, Nothing] = (acc, curr) => {
+    curr match {
+      case Right(currStatus) => acc.applyAndForceLeft(currStatus, concatStrings)
+      case Left(currError) => acc.applyAndForceLeft(currError, concatStrings)
+    }
+  }
+
+  val concatRight: (Either[String, String], Either[String, String]) => Either[String, String] = (acc, curr) => {
+    curr match {
+      case Right(currStatus) => acc.applyAndForceRight(currStatus, concatStrings)
+      case Left(currError) => acc.applyAndForceRight(currError, concatStrings)
+    }
+  }
+
+  implicit class FuturesEitherOps(future: List[Future[Either[String, String]]]) {
+    def reduceEithers(): Future[Either[String, String]] = {
+      Future.sequence(future).map { responses =>
+        if (responses.exists(_.isLeft)) {
+          responses.reduceLeft(concatLeft)
+        } else {
+          responses.reduceLeft(concatRight)
+        }
+      }
+    }
+  }
+
+}

--- a/src/main/scala/com/github/ilittleangel/notifier/utils/FixedList.scala
+++ b/src/main/scala/com/github/ilittleangel/notifier/utils/FixedList.scala
@@ -1,0 +1,54 @@
+package com.github.ilittleangel.notifier.utils
+
+import scala.collection._
+
+final class FixedList[A] private (val capacity: Int, val length: Int, val offset: Int, elems: Array[Any])
+  extends immutable.Iterable[A] with IterableOps[A, FixedList, FixedList[A]] { self =>
+
+  def this(capacity: Int) = this(capacity, length = 0, offset = 0, elems = Array.ofDim(capacity))
+
+  def appended[B >: A](elem: B): FixedList[B] = {
+    val newElems = Array.ofDim[Any](capacity)
+    Array.copy(elems, 0, newElems, 0, capacity)
+    val (newOffset, newLength) =
+      if (length == capacity) {
+        newElems(offset) = elem
+        ((offset + 1) % capacity, length)
+      } else {
+        newElems(length) = elem
+        (offset, length + 1)
+      }
+
+    new FixedList[B](capacity, newLength, newOffset, newElems)
+  }
+
+  @`inline` def :+ [B >: A](elem: B): FixedList[B] = appended(elem)
+
+  def apply(i: Int): A = elems((i + offset) % capacity).asInstanceOf[A]
+
+  override def iterator: Iterator[A] = new AbstractIterator[A] {
+    private var current = 0
+    override def hasNext: Boolean = current < self.length
+    override def next(): A = {
+      val elem = self(current)
+      current += 1
+      elem
+    }
+  }
+
+  override def className: String = "FixedList"
+  override val iterableFactory: IterableFactory[FixedList] = new FixedListFactory(capacity)
+  override protected def fromSpecific(coll: IterableOnce[A]): FixedList[A] = iterableFactory.from(coll)
+  override protected def newSpecificBuilder: mutable.Builder[A, FixedList[A]] = iterableFactory.newBuilder
+  override def empty: FixedList[A] = iterableFactory.empty
+
+}
+
+class FixedListFactory(capacity: Int) extends IterableFactory[FixedList] {
+  override def from[A](source: IterableOnce[A]): FixedList[A] = (newBuilder[A] ++= source).result()
+  override def empty[A]: FixedList[A] = new FixedList[A](capacity)
+  override def newBuilder[A]: mutable.Builder[A, FixedList[A]] =
+    new mutable.ImmutableBuilder[A, FixedList[A]](empty) {
+      override def addOne(elem: A): this.type = { elems = elems :+ elem; this}
+    }
+}

--- a/src/test/scala/com/github/ilittleangel/notifier/FixedListTest.scala
+++ b/src/test/scala/com/github/ilittleangel/notifier/FixedListTest.scala
@@ -1,0 +1,69 @@
+package com.github.ilittleangel.notifier
+
+import com.github.ilittleangel.notifier.destinations.Slack
+import com.github.ilittleangel.notifier.utils.{FixedList, FixedListFactory}
+import org.junit.runner.RunWith
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.junit.JUnitRunner
+
+
+@RunWith(classOf[JUnitRunner])
+class FixedListTest extends AnyWordSpec with Matchers {
+
+  private val mockAlert = Alert(List(Slack), s"message", None, None)
+  private val actionPerformed = ActionPerformed(mockAlert, isPerformed = false, "", "", None)
+
+  "FixedList" should {
+
+    "be able to manage a Scala collection with no truncated elements if capacity is not exceeded" in {
+      var alerts = new FixedList[ActionPerformed](capacity = 5).empty
+
+      (1 to 10).foreach { i =>
+        alerts = alerts :+ actionPerformed.copy(alert = mockAlert.copy(message = s"message_$i"))
+      }
+
+      alerts should have size 5
+      alerts.head.alert.message shouldBe "message_6"
+      alerts.last.alert.message shouldBe "message_10"
+    }
+
+    "be able to manage a Scala collection with the first elements truncated if capacity is exceeded" in {
+      var alerts = new FixedList[ActionPerformed](capacity = 20).empty
+
+      (1 to 10).foreach { i =>
+        alerts = alerts :+ actionPerformed.copy(alert = mockAlert.copy(message = s"message_$i"))
+      }
+
+      alerts should have size 10
+      alerts.head.alert.message shouldBe "message_1"
+      alerts.last.alert.message shouldBe "message_10"
+    }
+
+    "be able to be transformed from Scala Standard collections" in {
+      object FixedList extends FixedListFactory(capacity = 5)
+
+      val l = List(1, 2, 3, 4, 5, 6)
+      val fl = l.to(FixedList)
+
+      l  should have size 6
+      fl should have size 5
+      fl.head shouldBe 2
+      fl.last shouldBe 6
+    }
+
+    "be able to be transformed from Scala Standard collections with complex objects" in {
+      object FixedList extends FixedListFactory(capacity = 5)
+
+      val alerts = (1 to 20)
+        .map { i => actionPerformed.copy(alert = mockAlert.copy(message = s"message_$i")) }
+        .to(FixedList)
+
+      alerts should have size 5
+      alerts.head.alert.message shouldBe "message_16"
+      alerts.last.alert.message shouldBe "message_20"
+    }
+
+  }
+
+}

--- a/src/test/scala/com/github/ilittleangel/notifier/NotifierRoutesTest.scala
+++ b/src/test/scala/com/github/ilittleangel/notifier/NotifierRoutesTest.scala
@@ -4,11 +4,11 @@ import java.net.InetAddress
 import java.nio.charset.Charset
 import java.time.Instant
 
-import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.headers.`Remote-Address`
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, RemoteAddress}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import akka.util.Timeout
 import com.github.ilittleangel.notifier.destinations.Ftp
 import com.github.ilittleangel.notifier.server.NotifierRoutes
 import com.github.ilittleangel.notifier.utils.Eithers.separator
@@ -42,7 +42,7 @@ class NotifierRoutesTest extends WordSpec
     Ftp.configure(config)
   }
 
-  private implicit def defaultTimeout(implicit system: ActorSystem): RouteTestTimeout = RouteTestTimeout(5.seconds)
+  private implicit val testTimeout: RouteTestTimeout = RouteTestTimeout(Timeout(10.seconds).duration)
 
   "NotifierRoutes" should {
 

--- a/src/test/scala/com/github/ilittleangel/notifier/NotifierRoutesTest.scala
+++ b/src/test/scala/com/github/ilittleangel/notifier/NotifierRoutesTest.scala
@@ -57,7 +57,7 @@ class NotifierRoutesTest extends AnyWordSpec
         responseAs[String] should matchJson("[]")
       }
 
-      alerts shouldBe List.empty
+      alerts should have size 0
     }
 
     s"POST '/$basePath/$alertsEndpoint' be able to reject Slack alerts with no properties" in {
@@ -85,7 +85,7 @@ class NotifierRoutesTest extends AnyWordSpec
             |""".stripMargin)
       }
 
-      alerts shouldBe List.empty
+      alerts should have size 0
     }
 
     s"POST '/$basePath/$alertsEndpoint' be able to reject ftp alerts with no properties" in {
@@ -113,7 +113,7 @@ class NotifierRoutesTest extends AnyWordSpec
             |""".stripMargin)
       }
 
-      alerts shouldBe List.empty
+      alerts should have size 0
     }
 
     s"POST '/$basePath/$alertsEndpoint' be able to accept successful alerts" in {
@@ -168,12 +168,12 @@ class NotifierRoutesTest extends AnyWordSpec
 
         // checking alerts memory storage
         alerts should have size 1
-        alerts.head.isPerformed shouldBe true
-        alerts.head.description shouldBe AlertPerformed
-        alerts.head.status shouldBe "Ftp alert success [value=Done, count=16]"
-        alerts.head.alert.destination shouldBe List(Ftp)
-        alerts.head.alert.ts shouldBe Some(ts)
-        alerts.head.alert.message shouldBe "alarm process 1"
+        alerts.last.isPerformed shouldBe true
+        alerts.last.description shouldBe AlertPerformed
+        alerts.last.status shouldBe "Ftp alert success [value=Done, count=16]"
+        alerts.last.alert.destination shouldBe List(Ftp)
+        alerts.last.alert.ts shouldBe Some(ts)
+        alerts.last.alert.message shouldBe "alarm process 1"
 
         // checking sftp destination
         val fileContent = server.getFileContent(s"$homeDirectory/data.txt", Charset.forName("UTF-8"))
@@ -224,7 +224,7 @@ class NotifierRoutesTest extends AnyWordSpec
                |          "protocol": "sftp",
                |          "path": "$homeDirectory/data.txt"
                |      },
-               |      "ts": "${formatter.format(alerts.head.alert.ts.get)}"
+               |      "ts": "${formatter.format(alerts.last.alert.ts.get)}"
                |   },
                |   "isPerformed": true,
                |   "status": "Ftp alert success [value=Done, count=16]",
@@ -235,11 +235,11 @@ class NotifierRoutesTest extends AnyWordSpec
 
         // checking alerts memory storage
         alerts should have size 2
-        alerts.head.isPerformed shouldBe true
-        alerts.head.description shouldBe AlertPerformed
-        alerts.head.status shouldBe "Ftp alert success [value=Done, count=16]"
-        alerts.head.alert.destination shouldBe List(Ftp)
-        alerts.head.alert.message shouldBe "alarm process 2"
+        alerts.last.isPerformed shouldBe true
+        alerts.last.description shouldBe AlertPerformed
+        alerts.last.status shouldBe "Ftp alert success [value=Done, count=16]"
+        alerts.last.alert.destination shouldBe List(Ftp)
+        alerts.last.alert.message shouldBe "alarm process 2"
 
         // checking sftp destination
         val fileContent = server.getFileContent(s"$homeDirectory/data.txt", Charset.forName("UTF-8"))
@@ -302,11 +302,11 @@ class NotifierRoutesTest extends AnyWordSpec
 
         // checking alerts memory storage
         alerts should have size 3
-        alerts.head.isPerformed shouldBe false
-        alerts.head.description shouldBe AlertNotPerformed
-        alerts.head.status shouldBe "Ftp alert failed with an Exception [error=unsupported protocol]"
-        alerts.head.alert.destination shouldBe List(Ftp)
-        alerts.head.alert.message shouldBe "alarm process 3"
+        alerts.last.isPerformed shouldBe false
+        alerts.last.description shouldBe AlertNotPerformed
+        alerts.last.status shouldBe "Ftp alert failed with an Exception [error=unsupported protocol]"
+        alerts.last.alert.destination shouldBe List(Ftp)
+        alerts.last.alert.message shouldBe "alarm process 3"
 
         // checking sftp destination
         val fileContent = server.getFileContent(s"$homeDirectory/data.txt", Charset.forName("UTF-8"))
@@ -414,7 +414,7 @@ class NotifierRoutesTest extends AnyWordSpec
         responseAs[String] should matchJson("[]")
       }
 
-      alerts shouldBe List.empty
+      alerts should have size 0
     }
 
     s"POST '/$basePath/$alertsEndpoint' be able to accept multi destination alerts" in {
@@ -473,12 +473,12 @@ class NotifierRoutesTest extends AnyWordSpec
 
         // checking alerts in-memory
         alerts should have size 1
-        alerts.head.isPerformed shouldBe true
-        alerts.head.description shouldBe AlertPerformed
-        alerts.head.status.split(separator).length shouldBe 2
-        alerts.head.status shouldBe "Ftp alert success [value=Done, count=16]; Ftp alert success [value=Done, count=16]"
-        alerts.head.alert.destination shouldBe List(Ftp, Ftp)
-        alerts.head.alert.message shouldBe alarmMessage
+        alerts.last.isPerformed shouldBe true
+        alerts.last.description shouldBe AlertPerformed
+        alerts.last.status.split(separator).length shouldBe 2
+        alerts.last.status shouldBe "Ftp alert success [value=Done, count=16]; Ftp alert success [value=Done, count=16]"
+        alerts.last.alert.destination shouldBe List(Ftp, Ftp)
+        alerts.last.alert.message shouldBe alarmMessage
 
         // checking sftp destination
         val fileContent = server.getFileContent(s"$homeDirectory/data.txt", Charset.forName("UTF-8"))
@@ -537,11 +537,11 @@ class NotifierRoutesTest extends AnyWordSpec
 
       // checking alerts in-memory
       alerts should have size 2
-      alerts.head.isPerformed shouldBe false
-      alerts.head.description shouldBe AlertNotPerformed
-      alerts.head.status shouldBe failedStatus + separator + failedStatus
-      alerts.head.alert.destination shouldBe List(Ftp, Ftp)
-      alerts.head.alert.message shouldBe "alarm process 5"
+      alerts.last.isPerformed shouldBe false
+      alerts.last.description shouldBe AlertNotPerformed
+      alerts.last.status shouldBe failedStatus + separator + failedStatus
+      alerts.last.alert.destination shouldBe List(Ftp, Ftp)
+      alerts.last.alert.message shouldBe "alarm process 5"
     }
 
   }

--- a/src/test/scala/com/github/ilittleangel/notifier/NotifierRoutesTest.scala
+++ b/src/test/scala/com/github/ilittleangel/notifier/NotifierRoutesTest.scala
@@ -16,14 +16,16 @@ import com.github.stefanbirkner.fakesftpserver.lambda.FakeSftpServer.withSftpSer
 import com.stephenn.scalatest.circe.JsonMatchers
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.junit.JUnitRunner
 
 import scala.concurrent.duration.DurationInt
 
 
 @RunWith(classOf[JUnitRunner])
-class NotifierRoutesTest extends WordSpec
+class NotifierRoutesTest extends AnyWordSpec
   with Matchers with ScalatestRouteTest with JsonMatchers with NotifierRoutes with BeforeAndAfterAll {
 
   private val routes = notifierRoutes
@@ -480,7 +482,7 @@ class NotifierRoutesTest extends WordSpec
 
         // checking sftp destination
         val fileContent = server.getFileContent(s"$homeDirectory/data.txt", Charset.forName("UTF-8"))
-        fileContent.sliding(alarmMessage.length).count(_ == alarmMessage) shouldBe 2
+        fileContent.toSeq.sliding(alarmMessage.length).map(_.unwrap).count(_ == alarmMessage) shouldBe 2
         server.deleteAllFilesAndDirectories()
       }
     }


### PR DESCRIPTION
#### Description
* feat: **MULTI** destination support
In a single http request, the notifier can accept more than one destinations. In this case, the `destination` field must be an array for a proper deserialization.
* docs: update `README.md` and add `troubleshooting.md`
* fix: `build.gradle` mainClass
* chore: `docker` gradle task depends on assemble
* feat: setup **timeouts** from akka config file (`application.conf`)
* chore: upgrade to **Scala 2.13**
In`scalatest_2.13`, the `JUnitRunner` has been moved from `org.scalatest.junit` to `org.scalatestplus.junit`.
* feat: `FixedList` custom collection
To limit the `alerts` list capacity to an specific size, a custom Scala collection has been created. This implementation of custom collections is available with **Scala 2.13** and it is inspired on the following article:
https://docs.scala-lang.org/overviews/core/custom-collections.html
* feat: admin endpoint to set in-memory list capacity

#### Ticket
N/A

